### PR TITLE
Make network request return ByteString

### DIFF
--- a/functorrent.cabal
+++ b/functorrent.cabal
@@ -20,15 +20,17 @@ executable functorrent
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base,
-                       parsec,
-                       containers,
-                       time,
-                       bytestring,
-                       base16-bytestring,
-                       doctest,
                        HTTP,
+                       base16-bytestring,
+                       binary,
+                       bytestring,                    
+                       containers,
                        cryptohash,
-                       binary
+                       doctest,
+                       network-uri, 
+                       parsec,
+                       time
+
   hs-source-dirs:      src
   ghc-options:         -Wall -fwarn-incomplete-patterns
   default-language:    Haskell2010

--- a/src/Tracker.hs
+++ b/src/Tracker.hs
@@ -7,9 +7,11 @@ import Crypto.Hash.SHA1 (hash)
 import Data.ByteString.Char8 (ByteString, pack, unpack)
 import Data.Char (chr)
 import Data.List (intercalate)
+import Data.Maybe (fromJust)
 import Data.Map as M (Map, (!))
-import Network.HTTP (simpleHTTP, getRequest, getResponseBody)
+import Network.HTTP (simpleHTTP, defaultGETRequest_, getResponseBody)
 import Network.HTTP.Base (urlEncode)
+import Network.URI (parseURI)
 import Utils (splitN)
 import qualified Data.ByteString.Base16 as B16 (encode)
 
@@ -45,7 +47,6 @@ prepareRequest d peer_id len =
            ("event", "started")]
   in intercalate "&" [f ++ "=" ++ s | (f,s) <- p]
 
-connect :: Url -> String -> IO String
-connect baseurl qstr = let url = baseurl ++ "?" ++ qstr
-                       in simpleHTTP (getRequest url) >>=
-                          getResponseBody
+connect :: Url -> String -> IO ByteString
+connect baseurl qstr = simpleHTTP (defaultGETRequest_ url) >>= getResponseBody
+    where url = fromJust . parseURI $ (baseurl ++ "?" ++ qstr)


### PR DESCRIPTION
Packing and unpacking curropted the binary data in several occations
when the network response was written to disk for caching/testing.

Add support for local caches. This aids in testing, and throttling
remote requests if the file is new enough.

Removes unwanted <$>
