### PR TITLE
support for announce-list.

### DIFF
--- a/src/FuncTorrent/Metainfo.hs
+++ b/src/FuncTorrent/Metainfo.hs
@@ -89,6 +89,6 @@ getAnnounceList (Just (Blist l)) = map (\s -> case s of
 getAnnounceList (Just (Bdict _)) = []
 
 getTrackers :: Metainfo -> [String]
-getTrackers m = case (announce m) of
+getTrackers m = case announce m of
                  Nothing -> announceList m
                  Just a -> a : announceList m

--- a/src/FuncTorrent/Metainfo.hs
+++ b/src/FuncTorrent/Metainfo.hs
@@ -6,7 +6,8 @@ module FuncTorrent.Metainfo
      announce,
      lengthInBytes,
      info,
-     name
+     name,
+     getTrackers
     ) where
 
 import Prelude hiding (lookup)
@@ -25,8 +26,8 @@ data Info = Info { pieceLength :: !Integer
                  } deriving (Eq, Show)
 
 data Metainfo = Metainfo { info :: !Info
-                         , announce :: !String
-                         , announceList :: !(Maybe [[String]])
+                         , announce :: !(Maybe String)
+                         , announceList :: ![String]
                          , creationDate :: !(Maybe String)
                          , comment :: !(Maybe String)
                          , createdBy :: !(Maybe String)
@@ -55,20 +56,39 @@ maybeBstrToString (Just s) = let (Bstr bs) = s
 
 mkMetaInfo :: BVal -> Maybe Metainfo
 mkMetaInfo (Bdict m) = let (Just info') = mkInfo (m ! Bstr (pack "info"))
-                           (Bstr announce') = m ! Bstr (pack "announce")
-                           -- announceList = lookup (Bstr (pack "announce list"))
-                           announceList' = Nothing
+                           announce' = lookup (Bstr (pack "announce")) m
+                           announceList' = lookup (Bstr (pack "announce-list")) m
                            -- creationDate = lookup (Bstr (pack "creation date")) m
                            creationDate' = Nothing
                            comment' = lookup (Bstr (pack "comment")) m
                            createdBy' = lookup (Bstr (pack "created by")) m
                            encoding' = lookup (Bstr (pack "encoding")) m
                        in Just Metainfo { info = info'
-                                        , announce = unpack announce'
-                                        , announceList = announceList'
+                                        , announce = announce'
+                                                     >>= (\(Bstr a) ->
+                                                           Just (unpack a))
+                                        , announceList = getAnnounceList announceList'
                                         , creationDate = creationDate'
                                         , comment = maybeBstrToString comment'
                                         , createdBy = maybeBstrToString createdBy'
                                         , encoding = maybeBstrToString encoding'
                                         }
 mkMetaInfo _ = Nothing
+
+getAnnounceList :: Maybe BVal -> [String]
+getAnnounceList Nothing = []
+getAnnounceList (Just (Bint _)) = []
+getAnnounceList (Just (Bstr _)) = []
+getAnnounceList (Just (Blist l)) = map (\s -> case s of
+                                               (Bstr s') ->  unpack s'
+                                               (Blist s') -> case s' of
+                                                              [Bstr s''] -> unpack s''
+                                                              _ -> ""
+                                               _ -> "") l
+
+getAnnounceList (Just (Bdict _)) = []
+
+getTrackers :: Metainfo -> [String]
+getTrackers m = case (announce m) of
+                 Nothing -> announceList m
+                 Just a -> a : announceList m

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,7 +9,7 @@ import Text.ParserCombinators.Parsec (ParseError)
 
 import FuncTorrent.Bencode (decode, BVal(..))
 import FuncTorrent.Logger (initLogger, logMessage, logStop)
-import FuncTorrent.Metainfo (announce, lengthInBytes, mkMetaInfo, info, name)
+import FuncTorrent.Metainfo (lengthInBytes, mkMetaInfo, info, name, getTrackers)
 import FuncTorrent.Peer (peers, getPeerResponse, handShakeMsg)
 import FuncTorrent.Tracker (connect, prepareRequest)
 
@@ -46,9 +46,10 @@ main = do
 
               let len = lengthInBytes $ info m
                   (Bdict d') = d
+                  trackers = getTrackers m
 
               logMsg "Trying to fetch peers: "
-              body <- connect (announce m) (prepareRequest d' peerId len)
+              body <- connect (head trackers) (prepareRequest d' peerId len)
 
               -- TODO: Write to ~/.functorrent/caches
               writeFile (name (info m) ++ ".cache") body


### PR DESCRIPTION
This patch is towards #13.  Some torrent files use announce-lists but then store list of lists, 
each inner list containing just one string instead of list of strings. 
(eg: data/ubuntu-14.10-desktop-amd64.iso.torrent stores it this way)
