### PR TITLE
combine announce and announceList slots in the Metainfo record.

### DIFF
--- a/src/FuncTorrent.hs
+++ b/src/FuncTorrent.hs
@@ -5,7 +5,7 @@ module FuncTorrent
      Metainfo,
      Peer,
      PeerResp(..),
-     announce,
+     announceList,
      connect,
      decode,
      encode,

--- a/src/FuncTorrent/Bencode.hs
+++ b/src/FuncTorrent/Bencode.hs
@@ -2,6 +2,7 @@
 module FuncTorrent.Bencode
     (BVal(..),
      InfoDict,
+     bstrToString,
      encode,
      decode
     ) where
@@ -139,3 +140,8 @@ encode (Bstr bs) = pack $ show (length bs) ++ ":" ++ unpack bs
 encode (Bint i) = pack $ "i" ++ show i ++ "e"
 encode (Blist xs) = pack $ "l" ++ unpack (concat $ map encode xs) ++ "e"
 encode (Bdict d) = concat [concat ["d", encode . Bstr . pack $ k , encode (d ! k) , "e"] | k <- keys d]
+
+-- getters
+bstrToString :: BVal -> Maybe String
+bstrToString (Bstr s) = Just $ unpack s
+bstrToString _ = Nothing

--- a/src/FuncTorrent/Metainfo.hs
+++ b/src/FuncTorrent/Metainfo.hs
@@ -12,6 +12,7 @@ module FuncTorrent.Metainfo
 import Prelude hiding (lookup)
 import Data.ByteString.Char8 (ByteString, unpack)
 import Data.Map as M ((!), lookup)
+import Data.Maybe (maybeToList)
 
 import FuncTorrent.Bencode (BVal(..), bstrToString)
 
@@ -70,10 +71,6 @@ mkMetaInfo (Bdict m) = let (Just info') = mkInfo $ m ! "info"
                                         , encoding = maybeBstrToString encoding'
                                         }
 mkMetaInfo _ = Nothing
-
-maybeToList :: Maybe a -> [a]
-maybeToList  Nothing   = []
-maybeToList  (Just x)  = [x]
 
 getAnnounceList :: Maybe BVal -> [String]
 getAnnounceList Nothing = []

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ import Text.ParserCombinators.Parsec (ParseError)
 
 import FuncTorrent.Bencode (decode, BVal(..))
 import FuncTorrent.Logger (initLogger, logMessage, logStop)
-import FuncTorrent.Metainfo (lengthInBytes, mkMetaInfo, info, name, getTrackers)
+import FuncTorrent.Metainfo (lengthInBytes, mkMetaInfo, info, name, announceList)
 import FuncTorrent.Peer (peers, mkPeerResp, handShakeMsg)
 import FuncTorrent.Tracker (connect, prepareRequest)
 
@@ -51,7 +51,7 @@ main = do
 
               let len = lengthInBytes $ info m
                   (Bdict d') = d
-                  trackers = getTrackers m
+                  trackers = announceList m
 
               logMsg "Trying to fetch peers: "
               response <- connect (head trackers) (prepareRequest d' peerId len)


### PR DESCRIPTION
This eliminates the unnecessary "getter" function getTrackers
and simplifies the code a bit. Still a work in progress (Issue #12)
