### PR TITLE
Show nicer error messages on failure

### DIFF
--- a/src/FuncTorrent/Bencode.hs
+++ b/src/FuncTorrent/Bencode.hs
@@ -145,8 +145,10 @@ bencVal = Bstr <$> bencStr <|>
           Blist <$> bencList <|>
           Bdict <$> bencDict
 
-decode :: ByteString -> Either ParseError BVal
-decode = parse bencVal "BVal"
+decode :: ByteString -> Either String BVal
+decode bs = case (parse bencVal "BVal" bs) of
+           Left e -> Left "Unable to parse torrent file"
+           Right torrent -> Right torrent
 
 -- Encode BVal into a bencoded ByteString. Inverse of decode
 

--- a/src/FuncTorrent/Metainfo.hs
+++ b/src/FuncTorrent/Metainfo.hs
@@ -46,7 +46,7 @@ mkInfo (Bdict m) = let (Bint pieceLength') = m ! "piece length"
                                 , md5sum = md5sum'}
 mkInfo _ = Nothing
 
-mkMetaInfo :: BVal   -> Maybe Metainfo
+mkMetaInfo :: BVal   -> Either String Metainfo
 mkMetaInfo (Bdict m)  =
     let (Just info')  = mkInfo $ m ! "info"
         announce'     = lookup "announce" m
@@ -55,7 +55,7 @@ mkMetaInfo (Bdict m)  =
         comment'      = lookup "comment" m
         createdBy'    = lookup "created by" m
         encoding'     = lookup "encoding" m
-    in Just Metainfo {
+    in Right Metainfo {
              info         = info'
            , announceList = maybeToList (announce' >>= bstrToString)
                             ++ getAnnounceList announceList'
@@ -66,7 +66,7 @@ mkMetaInfo (Bdict m)  =
            , infoHash     = hash . encode $ (m ! "info")
         }
 
-mkMetaInfo _ = Nothing
+mkMetaInfo _ = Left "Unable to make Metainfo. Corrupt BString"
 
 getAnnounceList :: Maybe BVal -> [String]
 getAnnounceList Nothing = []

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -61,7 +61,7 @@ testMkMetaInfo :: TestTree
 testMkMetaInfo = testCase "Should mkInfo valid torrent files" $ do
                    str <- readFile "./data/hello.txt.torrent"
                    case decode str of
-                     Right expected -> mkMetaInfo expected @?= Just hello
+                     Right expected -> mkMetaInfo expected @?= Right hello
                      Left _ -> error "Failed parsing test file"
 
 testResponse1 :: TestTree


### PR DESCRIPTION
This patch adds framework for bubbling up error messages from the the
primitives.

Eg:

```
./.cabal-sandbox/bin/functorrent LICENSE
Starting up functorrent
Parsing input file LICENSE
Unable to parse torrent file
FuncTorrent: Exit succesfully
```
