### PR TITLE
Compartmentalize threads with bracket function

### DIFF
--- a/src/FuncTorrent/ControlThread.hs
+++ b/src/FuncTorrent/ControlThread.hs
@@ -1,18 +1,33 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- Description
+-- ControlThread handles all operations for a single torrent
+-- It is responsible for
+-- 1. Do parsing of torrent file.
+-- 2. Communicate with trackers and obtain peers
+-- 3. Initiate PeerThreads to do peer communication
+-- 4. Control the activity of PeerThreads
+-- 5. Maintain cache, etc
+-- 6. Handle incoming connections
+
+-- The overall operation may be divided into following parts
+-- 1. Initialization.
+-- 2. downloading/seeding.
+-- 3. Stopping download/seed.
+
 module FuncTorrent.ControlThread where
 
 import Control.Concurrent
-import Control.Monad hiding (forM, forM_, mapM, mapM_, msum, sequence, sequence_)
+import Control.Exception.Base  (bracket)
+import Control.Monad (foldM, void)
 import Data.IORef
-import GHC.Conc
 
 import FuncTorrent.Bencode (decode)
 import FuncTorrent.Metainfo (Metainfo(..))
 import FuncTorrent.Tracker (TrackerResponse(..), tracker, mkTrackerResponse, peers)
 
 import FuncTorrent.Peer (Peer(..))
-import FuncTorrent.PeerThread
+import FuncTorrent.PeerThread (initPeerThread)
 import FuncTorrent.PeerThreadData
 
 data ControlThread = ControlThread
@@ -37,85 +52,16 @@ data ControlThreadAction =
     |   Stop
   deriving (Eq, Show)
 
--- Description
--- ControlThread handles all operations for a single torrent
--- It is responsible for
--- 1. Do parsing of torrent file.
--- 2. Communicate with trackers and obtain peers
--- 3. Initiate PeerThreads to do peer communication
--- 4. Control the activity of PeerThreads
--- 5. Maintain cache, etc
--- 6. Handle incoming connections
-
--- The overall operation may be divided into following parts
--- 1. Initialization.
--- 2. downloading/seeding.
--- 3. Stopping download/seed.
---
-controlThreadMain :: ControlThread -> IO ()
-controlThreadMain ct =
-    doExit =<< (mainLoop <=< doInitialization) ct
-
-doInitialization :: ControlThread -> IO ControlThread
-doInitialization ct =
+initialize :: ControlThread -> IO ControlThread
+initialize ct =
   getTrackerResponse ct >>= \x ->
       let peerInit = take 4 (peerList x)
       in foldM forkPeerThread x peerInit
 
-mainLoop :: ControlThread -> IO ControlThread
-mainLoop ct =
-  -- At this stage rank peers and decide if we want to disconnect
-  -- And create more peers/ use incoming connections.
-  filterBadPeers ct >>=
-
-  pieceManagement >>=
-
-  -- Loop Here and check if we need to quit/exit
-  -- Add delay here before polling PeerThreads again
-  checkAction
-
- where
-   checkAction :: ControlThread -> IO ControlThread
-   checkAction ct1 = do
-     putStrLn "Check control thread action"
-     -- TODO: This will cause a 4s delay b/w a ^C and the app going down
-     threadDelay $ 4*1000*1000
-     action <- readIORef $ controlTAction ct1
-     case action of
-       FuncTorrent.ControlThread.Stop -> return ct1
-       _ -> mainLoop ct1
-
-doExit :: ControlThread -> IO ()
-doExit ct = do
-  putStrLn "Doing control-thread exit"
-  let peerTs = peerThreads ct
-  -- let the peer threads stop themselves
-  mapM_ (setPeerThreadAction FuncTorrent.PeerThreadData.Stop . fst) peerTs
-
-  -- Let the threads run for a while
-  -- We may add delay also if required
-  yield
-
-  -- remove all the threads which stopped successfully
-  ct1 <- clearFinishedThreads ct
-
-  -- If there are still threads waiting/blocked then either wait
-  -- if they are blocked due to disk write, then wait and retry
-  -- if thread not responding then kill the thread
-
-  unless (null (peerThreads ct1)) $ doExit ct1
-
- where
-     clearFinishedThreads :: ControlThread -> IO ControlThread
-     clearFinishedThreads ct1 = do
-       remainingThreads <- filterM isRunning (peerThreads ct1)
-       return (ct1 {peerThreads = remainingThreads})
-      where
-          isRunning (_,tid) =
-              threadStatus tid >>= (\x -> return $ ThreadFinished /= x)
-
+-- | Inappropriately named function. Adds tracker information to control thread
 getTrackerResponse :: ControlThread -> IO ControlThread
 getTrackerResponse ct = do
+  putStrLn "Get tracker response"
   response <- tracker (metaInfo ct) "-HS0001-*-*-20150215"
 
   -- TODO: Write to ~/.functorrent/caches
@@ -131,6 +77,38 @@ getTrackerResponse ct = do
                           peerList = newPeerList}
           Left _ -> putStrLn "mkTracker error" >> return ct
     Left _ -> putStrLn "tracker resp decode error" >> return ct
+
+-- Control thread loop. This is where all the action happens
+loop :: ControlThread -> IO ControlThread
+loop ct =
+    -- At this stage rank peers and decide if we want to disconnect
+    -- And create more peers/ use incoming connections.
+    filterBadPeers ct >>=
+
+    pieceManagement >>=
+
+    -- Loop Here and check if we need to quit/exit
+    -- Add delay here before polling PeerThreads again
+    checkAction
+
+  where
+    -- | Polls `controlTAction` for messages and act accordingly
+    checkAction :: ControlThread -> IO ControlThread
+    checkAction ct1 = do
+        putStrLn "Check control thread action"
+        -- TODO: This will cause a 4s delay b/w a signal and the action
+        threadDelay $ 4 * 1000 * 1000
+        action <- readIORef $ controlTAction ct1
+
+        case action of
+          _ -> loop ct1
+
+cleanup :: ControlThread -> IO ()
+cleanup ct = do
+  putStrLn "Exit control thread killing all peer threads"
+
+  -- Kill all the peer threads. killThread is synchronous, no need to wait.
+  mapM_ (killThread . snd) $ peerThreads ct
 
 -- Forks a peer-thread and add it to the peerThreads list
 forkPeerThread :: ControlThread -> Peer -> IO ControlThread
@@ -152,8 +130,12 @@ filterBadPeers ct = do
 
 initControlThread :: Metainfo -> IO (ControlThread, ThreadId)
 initControlThread m = do
-  st <- newIORef Stopped
-  a  <- newIORef Download
-  let ct = ControlThread m [] [] [] st a
-  tid <- forkIO $ controlThreadMain ct
-  return (ct, tid)
+    st <- newIORef Stopped
+    a  <- newIORef Download
+    let ct = ControlThread m [] [] [] st a
+    tid <- forkIO $ bracket (initialize ct) cleanup action
+    return (ct, tid)
+  where
+    -- forkIO needs an action which returns nothing
+    action :: ControlThread -> IO ()
+    action ct = return $ void loop ct

--- a/src/FuncTorrent/PeerThread.hs
+++ b/src/FuncTorrent/PeerThread.hs
@@ -45,6 +45,8 @@ import FuncTorrent.PeerThreadMain (peerThreadMain)
 
 initPeerThread :: Peer -> IO (PeerThread, ThreadId)
 initPeerThread p = do
+  putStrLn $ "Fork new peer thread for " ++ show p
+
   s <- newEmptyMVar
   a <- newEmptyMVar
   --i <- newIORef defaultPeerState
@@ -56,18 +58,14 @@ initPeerThread p = do
   _ <- setPeerThreadAction InitPeerConnection pt
   return (pt, tid)
 
-
--- Gracefully exit a thread
-stopPeerThread :: PeerThread -> IO ()
-stopPeerThread _ = undefined
-
--- Control thread will get status from this API
--- It should not block due to Peer-Thread
+-- Control thread will get status from this API. It should not block due to
+-- Peer-Thread
+-- [todo] - Make it clear, why would it block ?
 getPeerThreadStatus :: PeerThread -> IO (Maybe PeerThreadStatus)
 getPeerThreadStatus pt = tryReadMVar $ peerTStatus pt
 
-
--- Peer Thread may block, if no action is recieved from Control-thread
--- It may also kill itself if no communication from Control-thread for some time.
+-- Peer Thread may block, if no action is recieved from Control-thread It may
+-- also kill itself if no communication from Control-thread for some time.
+-- [todo] - Make it clear, why would it block ?
 setPeerThreadAction :: PeerThreadAction -> PeerThread -> IO Bool
 setPeerThreadAction a pt = tryPutMVar (peerTAction pt) a

--- a/src/FuncTorrent/PeerThreadData.hs
+++ b/src/FuncTorrent/PeerThreadData.hs
@@ -28,7 +28,6 @@ data PeerThreadAction
     | GetPieces [Piece]
     | Seed
     | StayIdle
-    | Stop
     deriving (Eq,Show)
 
 data PeerThread = PeerThread


### PR DESCRIPTION
- Fixed the delay b/w ^c and app responding to that
- Added a bunch of [todo] and [review]. All of them needs to be sorted
  out.
- All threads have the `initialize`, `loop` and `cleanup` functions
  defined. Consistency is great!
- The 3 functions are wrapped in a `bracket` is spawned with `forkIO`
- Threads no longer poll for stop signal, but they do for everything
  else. It should be safe to kill threads anytime. Polling for stop
  signal will work for regular operations, but will make use cases like
  timeouts, exceptions, user killing with a `pkill -9` etc really tricky
  to implement. This simplifies that.
- Again, removed a whole lot of unused code. Can always get it back from
  git if needed. It really makes it hard to read code with unused bits.
- Fixed imports for GHC 7.8 and 7.10
- Added a lot more print statements. Need to move to logging
  infrastructure
- Lint fixes
