### PR TITLE
Use watson for micro issues

### DIFF
--- a/.watsonrc
+++ b/.watsonrc
@@ -1,0 +1,22 @@
+# watson - inline issue manager
+# http://goosecode.com/watson/
+
+# Directories
+[dirs]
+./
+
+[show_type]
+dirty
+
+# Tags
+[tags]
+fix
+review
+todo
+
+# Ignores
+[ignore]
+*.swp
+.DS_Store
+.stack
+.git

--- a/src/FuncTorrent/Bencode.hs
+++ b/src/FuncTorrent/Bencode.hs
@@ -153,10 +153,10 @@ decode bs = case parse bencVal "BVal" bs of
 
 -- Encode BVal into a bencoded ByteString. Inverse of decode
 
--- TODO: Use builders and lazy byte string to get O(1) concatenation over O(n)
+-- [todo] - Use builders and lazy byte string to get O(1) concatenation over O(n)
 -- provided by lists.
 
--- TODO: encode . decode pair might be a good candidate for Quickcheck.
+-- [todo] - encode . decode pair might be a good candidate for Quickcheck.
 -- | encode bencoded-values
 --
 -- >>> encode (Bstr (pack ""))

--- a/src/FuncTorrent/ControlThread.hs
+++ b/src/FuncTorrent/ControlThread.hs
@@ -78,7 +78,7 @@ mainLoop ct =
    checkAction :: ControlThread -> IO ControlThread
    checkAction ct1 = do
      putStrLn "Check control thread action"
-     -- TODO: This will cause a 4s delay b/w a ^C and the app going down
+     -- [todo] - This will cause a 4s delay b/w a ^C and the app going down
      threadDelay $ 4*1000*1000
      action <- readIORef $ controlTAction ct1
      case action of
@@ -118,7 +118,7 @@ getTrackerResponse :: ControlThread -> IO ControlThread
 getTrackerResponse ct = do
   response <- tracker (metaInfo ct) "-HS0001-*-*-20150215"
 
-  -- TODO: Write to ~/.functorrent/caches
+  -- [todo] - Write to ~/.functorrent/caches
   -- writeFile (name (info m) ++ ".cache") response
 
   case decode response of

--- a/src/FuncTorrent/Network.hs
+++ b/src/FuncTorrent/Network.hs
@@ -13,7 +13,7 @@ import Network.HTTP (simpleHTTP, defaultGETRequest_, getResponseBody)
 import Network.URI (parseURI)
 
 -- | Make a query string from a alist of k, v
--- TODO: Url encode each argument
+-- [todo] - Url encode each argument
 mkParams :: [(String, ByteString)] -> ByteString
 mkParams params = BC.intercalate "&" [concat [pack f, "=", s] | (f,s) <- params]
 

--- a/src/FuncTorrent/Tracker.hs
+++ b/src/FuncTorrent/Tracker.hs
@@ -70,9 +70,8 @@ tracker :: Metainfo -> String -> IO ByteString
 tracker m peer_id = get (head . announceList $ m) $ mkArgs m peer_id
 
 --- | URL encode hash as per RFC1738
---- TODO: Add tests
---- REVIEW: Why is this not written in terms of `Network.HTTP.Base.urlEncode` or
---- equivalent library function?
+--- [todo] - Add tests for URL encode hash
+--- [review] - Write urlEncodeHash with Network.HTTP.Base.urlEncode or something
 urlEncodeHash :: ByteString -> String
 urlEncodeHash bs = concatMap (encode' . unpack) (splitN 2 bs)
   where encode' b@[c1, c2] = let c =  chr (read ("0x" ++ b))

--- a/test/PeerThreadMock.hs
+++ b/test/PeerThreadMock.hs
@@ -14,7 +14,7 @@ import FuncTorrent.PeerThreadData
 peerThreadMain :: PeerThread -> IO ()
 peerThreadMain pt = do
   toDoAction <- getAction
-  -- TODO: Non exhaustive pattern match
+  -- [todo] - Non exhaustive pattern match
   case toDoAction of
     InitPeerConnection -> do
       threadDelay $ 1000*1000


### PR DESCRIPTION
`watson` is a tiny inline issue manager, which can grep through source
and report things that need to be done. Its basically a pretty looking
grep.

There is no need for everyone to use it, but its good to have. The only
extra effort is to annotate all FIX/TODO/REVIEW in a consistent manner,
which will help even if you don't use the tool. See the diff for
details.

See the details here: http://goosecode.com/watson/

As of now, a sample output from watson looks like this:

```
------------------------------
watson - inline issue manager
Run in: /Users/j/Projects/functorrent
Run @ Sun Nov 15 01:07:06 2015
------------------------------

[ x ] src/FuncTorrent/Bencode.hs
[ todo ]
  line 156 - Use builders and lazy byte string to get O(1) concatenation over O(n)
  line 159 - encode . decode pair might be a good candidate for Quickcheck.

[ x ] src/FuncTorrent/ControlThread.hs
[ todo ]
  line 81 - This will cause a 4s delay b/w a ^C and the app going down
  line 121 - Write to ~/.functorrent/caches

[ x ] src/FuncTorrent/Network.hs
[ todo ]
  line 16 - Url encode each argument

[ x ] src/FuncTorrent/Tracker.hs
[ review ]
  line 74 - Write urlEncodeHash with Network.HTTP.Base.urlEncode or something

[ todo ]
  line 73 - Add tests for URL encode hash

[ x ] test/PeerThreadMock.hs
[ todo ]
  line 17 - Non exhaustive pattern match
```
